### PR TITLE
Removes hash tag from URL

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -19,7 +19,6 @@ var app = {
   },
 
   getSection: function(url) {
-
     $.ajax({
 
       url: "elements/" + url
@@ -50,15 +49,16 @@ var app = {
   },
 
   updateURL: function(url) {
-    window.location.hash = url;
+    // window.location.hash = url;
+    var stateObj = { foo: "bar" };
+    history.pushState(stateObj, url, url);
   },
 
   // This function controls what element will show based on the URL the page loads with.
   setUpFirstView: function() {
 
-    // Look for hash
-    var hash = window.location.hash;
-    var url = hash.replace("#", "");
+    var path = window.location.pathname;
+    var url = path.replace("/", "");
 
     // If there is one...
     if (url) {


### PR DESCRIPTION
:construction: Working on removing the hashtag from the URL, this gets the URL to show correctly but will not actually take you to the correct page.  Kevin said it's a server issue and we may not be able to do it through GitHub.  

Under Construction until we know more of what we can or cannot do in regards to this.
