### PR TITLE
Fixes example code box to scrollable so word wrap doesn't mess up the…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -297,7 +297,7 @@ h4 {
   font-family: "Roboto-Mono", monaco, monospace;
   font-size: 0.8rem;
   padding: 1rem;
-  white-space: pre-wrap;
+  overflow: auto;
 }
 
 .code-example strong {


### PR DESCRIPTION
 Making example coding box scrollable so that code does not get rearranged when with word wrap and put it out of proper format.

[x] Make Example Code box scrollable left to right so code does not get rearranged on word wrap.
[x ] Verify this works and is best fix for the problem.
