### PR TITLE
Updates linter to latest version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,9 @@ module.exports = {
       "always"
     ],
     "no-multiple-empty-lines": [2, {"max": 2}],
+    "space-in-parens": [2, "never"],
+    "keyword-spacing": [2, { "before": true}],
+    "keyword-spacing": [2, { "after": true}],
     "no-lone-blocks": 2
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,24 +8,24 @@ module.exports = {
     "ga": true
   },
   "rules": {
-    "indent": [2, 2],
+    "indent": ["error", 2],
     "linebreak-style": [
-      2,
+      "error",
       "unix"
     ],
-    "no-trailing-spaces": 2,
+    "no-trailing-spaces": "error",
     "quotes": [
-      2,
+      "error",
       "single"
     ],
     "semi": [
-      2,
+      "error",
       "always"
     ],
-    "no-multiple-empty-lines": [2, {"max": 2}],
-    "space-in-parens": [2, "never"],
-    "keyword-spacing": [2, { "before": true}],
-    "keyword-spacing": [2, { "after": true}],
-    "no-lone-blocks": 2
+    "no-multiple-empty-lines": ["error", {"max": 2}],
+    "space-in-parens": ["error", "never"],
+    "keyword-spacing": ["error", { "before": true, "after": true}],
+    "space-before-blocks": "error",
+    "no-lone-blocks": "error"
   },
 };

--- a/js/button.js
+++ b/js/button.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
 
   audio.onpause = setPause;
 
-  $('body').on( 'click', '.play-button', function(event) {
+  $('body').on('click', '.play-button', function(event) {
     var $button = $(event.target);
     var audioSrc = $button.data('audio-src');
     var isPreviousButton = new RegExp(audioSrc).test(audio.src);

--- a/js/combobox.js
+++ b/js/combobox.js
@@ -24,7 +24,7 @@ $(function() {
 
       this.input = $('<input>')
         .appendTo(this.wrapper)
-        .val( value )
+        .val(value)
         .attr('title', '')
         .addClass('custom-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left')
         .autocomplete({
@@ -88,7 +88,7 @@ $(function() {
             value: text,
             option: this
           };
-      }) );
+      }));
     },
 
     _removeIfInvalid: function(event, ui) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/adorableio/LMHT#readme",
   "devDependencies": {
-    "eslint": "^1.10.3"
+    "eslint": "^2.13.1"
   }
 }


### PR DESCRIPTION
In order to keep the linter up to date
As an LMHT coder,
I want the latest version of the linter installed so we are always using the latest rules on ESlint

Acceptance Criteria:
Install latest version of linter 2.13.1
Update the rules with any requests that could not be accomplished in other PR's because we had previous version.

Given any LMHT coder,
I want to be using the latest greatest linter files so everything works smoothly based on the latest data.
